### PR TITLE
Versionierung für Initiativen

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ git+https://github.com/DemokratieInBewegung/django-mailer.git
 django-mathfilters==0.4.0
 django-model-utils==3.0.0
 django-notifications-hq==1.2
+django-reversion==2.0.9
 django-tag-parser==2.1
 django-user-accounts==2.0.1
 djangoajax==2.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ appdirs==1.4.3
 beautifulsoup4==4.6.0
 bleach==2.0.0
 defusedxml==0.5.0
+diff-match-patch==20121119
 dj-database-url==0.4.2
 Django==1.10.6
 django-appconf==1.0.2
@@ -15,6 +16,7 @@ django-mathfilters==0.4.0
 django-model-utils==3.0.0
 django-notifications-hq==1.2
 django-reversion==2.0.9
+django-reversion-compare==0.7.5
 django-tag-parser==2.1
 django-user-accounts==2.0.1
 djangoajax==2.3.7

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -10,4 +10,7 @@ SECRET_KEY=temp_value python manage.py collectstatic -v 0 --clear --noinput
 echo "Apply database migrations"
 python manage.py migrate
 
+echo "Creating new revisions"
+python manage.py createinitialrevisions
+
 echo "------ Upgrade done -----"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -11,6 +11,6 @@ echo "Apply database migrations"
 python manage.py migrate
 
 echo "Creating new revisions"
-python manage.py createinitialrevisions
+python manage.py createinitialrevisions --comment "Erste Fassung"
 
 echo "------ Upgrade done -----"

--- a/templates/fragments/compare.html
+++ b/templates/fragments/compare.html
@@ -1,0 +1,87 @@
+
+{% load avatar_tags %}
+<div class="container">
+    <div class="row">
+        <div class="col">
+            <a href="/initiative/{{initiative.id}}-{{initiative.slug}}" class="go-to-index"><i class="material-icons chevron-left">chevron_left</i>zurück zur Initiative</a>
+        </div>
+    </div>
+	<div class="row">
+		<h2>Änderungshistorie Initiative #{{initiative.id}}</h2>	
+	</div>
+
+	<div class="row">
+		<div class="col-md-4 text-right">
+	        <h6 class="text-muted classification">Vergleiche Version</h6>
+	        <div class="dropdown">
+	        	<a id="versionSelectDropdown" href="#" class="dropdown-toggle" data-toggle="dropdown" aria-has-popup="true" aria-expanded="false"><strong>{{selected.revision.date_created}}</strong> {% if selected.revision.user %} — {% avatar selected.revision.user 25 %}{% endif %}</a>
+	        	<br />{% if selected.revision.comment %}<em>{{selected.revision.comment}}</em>{% endif %}
+
+	        	<div class="dropdown-menu dropdown-menu-right " aria-labelledby="versionSelectDropdown">
+	        		{% for v in initiative.versions %}
+	        			{% if v == latest %}
+	        			{% else %}
+	        				<a href="/initiative/{{initiative.id}}-{{initiative.slug}}/compare/{{v.id}}"
+	        					class="dropdown-item"
+	        					data-ajax="true">
+	        					{% if v == selected %}<strong>{%endif%}
+
+	        					{{v.revision.date_created}} {% if v.revision.user %} — {% avatar v.revision.user 12 %}{% endif %}
+
+	        					{% if v == selected %}</strong>{%endif%}
+	        				</a>
+	        			{% endif %}
+	        		{% endfor %}
+                </div>
+	        </div> 
+	    </div>
+		<div class="col-md-8">
+	        <h6 class="text-muted classification">mit Aktueller Version</h6>
+	        <div>
+	        	<strong>{{latest.revision.date_created}}</strong> {% if latest.revision.user %} — {% avatar latest.revision.user 25 %}{% endif %}
+	        	<br />{% if latest.revision.comment %}<em>{{latest.revision.comment}}</em>{% endif %}
+	        </div>
+	</div>
+</div>
+
+<hr />
+
+<div class="container-fluid">
+    <div class="container">
+        <div class="row initiative-title">
+            <div class="col-12">
+                <h1 class="display-4">{{compare.title}}</h1>
+            </div>
+        </div>
+        <div class="row initiative-subtitle">
+            <div class="col-12">
+                <p>{{compare.subtitle}}</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% include "initproc/blocks/meta.html" with initiative=compare %}
+
+<div class="container">
+<div class="row initiative-text">
+    <div class="col-12">
+    	<h3>Zusammenfassung</h3>
+        {{compare.summary}}
+        <h2>Problembeschreibung</h2>
+        {{compare.problem}}
+        <h2>Forderung</h2>
+        {{compare.forderung}}
+        <h2>Kosten</h2>
+        {{compare.kosten}}
+        <h2>Finanzierungsvorschlag</h2>
+        {{compare.fin_vorschlag}}
+        <h2>Arbeitsweise</h2>
+        {{compare.arbeitsweise}}
+        <h2>Argument der Initiatoren</h2>
+        <blockquote class="blockquote">
+            {{compare.init_argument}}
+        </blockquote>
+    </div>
+</div>
+</div>

--- a/templates/initproc/blocks/content.html
+++ b/templates/initproc/blocks/content.html
@@ -1,0 +1,20 @@
+{% load markdown %}
+<div class="row initiative-text">
+    <div class="col-12">
+        {{initiative.summary|markdown}}
+        <h2>Problembeschreibung</h2>
+        {{initiative.problem|markdown}}
+        <h2>Forderung</h2>
+        {{initiative.forderung|markdown}}
+        <h2>Kosten</h2>
+        {{initiative.kosten|markdown}}
+        <h2>Finanzierungsvorschlag</h2>
+        {{initiative.fin_vorschlag|markdown}}
+        <h2>Arbeitsweise</h2>
+        {{initiative.arbeitsweise|markdown}}
+        <h2>Argument der Initiatoren</h2>
+        <blockquote class="blockquote">
+            {{initiative.init_argument|markdown}}
+        </blockquote>
+    </div>
+</div>

--- a/templates/initproc/blocks/meta.html
+++ b/templates/initproc/blocks/meta.html
@@ -1,0 +1,37 @@
+
+<div class="container-fluid meta">
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-12 col-md-4">
+                <h6 class="text-muted classification">Veröffentlicht am</h6>
+                <div>
+                {% if initiative.went_public_at %}
+                    {{initiative.went_public_at}}
+                {% else %}
+                    Noch nicht veröffentlicht
+                {% endif %}
+                </div>
+            </div>
+            <div class="col-sm-12 col-md-8">
+                <h6 class="text-muted classification">Bereich</h6>
+                <div>
+                    {{initiative.bereich}}
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-12 col-md-4">
+                <h6 class="text-muted classification">Einordnung</h6>
+                <div>
+                    {{initiative.einordnung}}
+                </div>
+            </div>
+            <div class="col-sm-12 col-md-8">
+                <h6 class="text-muted classification">Ebene</h6>
+                <div>
+                    {{initiative.ebene}}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/initproc/item.html
+++ b/templates/initproc/item.html
@@ -297,7 +297,7 @@
             <h6 class="col-md-6 text-muted classification">Text der Initiative</h6>
             {% if initiative.versions.count > 1 %}
                 <div class="col-md-6 text-muted text-right">
-                    <a href=""><span class="material-icons">history</span> {{initiative.versions.count}}</a>
+                    <a href="/initiative/{{initiative.id}}-{{initiative.slug}}/compare/{{initiative.versions.1.id}}" data-ajax="true"><span class="material-icons">history</span> {{initiative.versions.count}}</a>
                 </div>
             {% endif %}
         </div>

--- a/templates/initproc/item.html
+++ b/templates/initproc/item.html
@@ -357,9 +357,17 @@
 {% block content %}
 <div id="initiative-text" class="container-fluid initiative-single">
     <div class="container">
+        <div class="row">
+            <h6 class="col-md-6 text-muted classification">Text der Initiative</h6>
+            {% if initiative.versions.count > 1 %}
+                <div class="col-md-6 text-muted text-right">
+                    <a href=""><span class="material-icons">history</span> {{initiative.versions.count}}</a>
+                </div>
+            {% endif %}
+        </div>
+
         <div class="row initiative-text">
             <div class="col-12">
-                <h6 class="text-muted classification">Text der Initiative</h6>
                 {{initiative.summary|markdown}}
                 <h2>Problembeschreibung</h2>
                 {{initiative.problem|markdown}}

--- a/templates/initproc/item.html
+++ b/templates/initproc/item.html
@@ -22,46 +22,6 @@
                 <a href="/" class="go-to-index"><i class="material-icons chevron-left">chevron_left</i>zur Übersicht</a>
             </div>
         </div>
-        <!--<div class="row initiative-state">
-            <div class="col-12">
-                <div class="d-flex flex-wrap">
-                    {% ifequal initiative.state 'i' %}
-                    <span class="badge badge-arrivals">
-                        Noch nicht veröffentlicht
-                    </span> {% endifequal %} {% ifequal initiative.state 'm' %}
-                    <span class="badge badge-arrivals">
-                        Wird gerade moderiert
-                    </span> {% endifequal %} {% ifequal initiative.state 'h' %}
-                    <span class="badge badge-arrivals">
-                        Versteckt
-                    </span> {% endifequal %} {% ifequal initiative.state 's' %}
-                    <span class="badge badge-support">
-                        Sucht Unterstützung
-                    </span> {% endifequal %} {% ifequal initiative.state 'd' %}
-                    <span class="badge badge-discussion">
-                        In Diskussion
-                    </span> {% endifequal %} {% ifequal initiative.state 'e' %}
-                    <span class="badge badge-edits">
-                        Finale Überarbeitung
-                    </span> {% endifequal %} {% ifequal initiative.state 'v' %}
-                    <span class="badge badge-vote">
-                        Abstimmung
-                    </span> {% endifequal %} {% ifequal initiative.state 'a' %}
-                    <span class="badge badge-accepted">
-                        Angenommen
-                    </span> {% endifequal %} {% ifequal initiative.state 'r' %} {% if initiative.went_to_discussion_at %}
-                    <span class="badge badge-rejected">
-                        Abstimmung: Abgelehnt
-                    </span> {% else %}
-                    <span class="badge badge-rejected">
-                        Sucht Unterstützung: gescheitert
-                    </span> {% endif %} {% endifequal %}
-                    <span class="text-muted">
-                        Noch {{initiative.end_of_this_phase | timeuntil}}
-                    </span>
-                </div>
-            </div>
-        </div>-->
         <div class="row initiative-title">
             <div class="col-12">
                 <h1 class="display-4">{{initiative.title}}</h1>
@@ -77,6 +37,15 @@
                 <a href="#initiative-text" class="skip-meta"><i class="material-icons expand-more">expand_more</i>Zum Text der Initiative</a>
             </div>
         </div>
+    </div>
+</div>
+
+
+{% endblock %}
+{% block content %}
+
+<div class="container-fluid">
+    <div class="container">
         <div class="row initiative-state">
             <div class="col-12">
                 {% if initiative.state == 'p' or initiative.state == 'i' %}
@@ -179,6 +148,8 @@
         </div>
     </div>
 </div>
+
+
 <div class="container-fluid initiators">
     <div class="container">
         <div class="row">
@@ -232,42 +203,8 @@
     </div>
 </div>
 
-<div class="container-fluid meta">
-    <div class="container">
-        <div class="row">
-            <div class="col-sm-12 col-md-4">
-                <h6 class="text-muted classification">Veröffentlicht am</h6>
-                <div>
-                {% if initiative.went_public_at %}
-                    {{initiative.went_public_at}}
-                {% else %}
-                    Noch nicht veröffentlicht
-                {% endif %}
-                </div>
-            </div>
-            <div class="col-sm-12 col-md-8">
-                <h6 class="text-muted classification">Bereich</h6>
-                <div>
-                    {{initiative.bereich}}
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-sm-12 col-md-4">
-                <h6 class="text-muted classification">Einordnung</h6>
-                <div>
-                    {{initiative.einordnung}}
-                </div>
-            </div>
-            <div class="col-sm-12 col-md-8">
-                <h6 class="text-muted classification">Ebene</h6>
-                <div>
-                    {{initiative.ebene}}
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
+
+{% include "initproc/blocks/meta.html" %}
 
 {% include "initproc/blocks/variants.html" %}
 
@@ -337,6 +274,7 @@
     </div>
 </div>
 {% endifequal %}
+
 {% ifequal initiative.state 'd' %}
 <div id="cta" class="container-fluid cta">
     <div class="container">
@@ -352,9 +290,7 @@
     </div>
 </div>
 {% endifequal %}
-{% endblock %}
 
-{% block content %}
 <div id="initiative-text" class="container-fluid initiative-single">
     <div class="container">
         <div class="row">
@@ -366,47 +302,27 @@
             {% endif %}
         </div>
 
-        <div class="row initiative-text">
-            <div class="col-12">
-                {{initiative.summary|markdown}}
-                <h2>Problembeschreibung</h2>
-                {{initiative.problem|markdown}}
-                <h2>Forderung</h2>
-                {{initiative.forderung|markdown}}
-                <h2>Kosten</h2>
-                {{initiative.kosten|markdown}}
-                <h2>Finanzierungsvorschlag</h2>
-                {{initiative.fin_vorschlag|markdown}}
-                <h2>Arbeitsweise</h2>
-                {{initiative.arbeitsweise|markdown}}
-                <h2>Argument der Initiatoren</h2>
-                <blockquote class="blockquote">
-                    {{initiative.init_argument|markdown}}
-                    <!--<div class="avatar">
-                        {% for sup in initiative.initiators.all %} {% avatar sup.user 35 %} {% endfor %}
-                    </div>-->
-                </blockquote>
+        {% include "initproc/blocks/content.html" %}
+        
+        {% if initiative.was_closed_at %}
+            <div class="row">
+                <div class="col-12">
+                    <h3 class="history-title">
+                    <span class="date">{{initiative.was_closed_at}}</span>
+                    {% if initiative.went_to_discussion_at %}
+                      Nach Abstimmung mit {{ initiative.yays|default:0 }} Für- und {{ initiative.nays|default:0 }} Gegenstimmen
+                      {% ifequal initiative.state 'a' %}
+                        angenommen.
+                      {% else %}
+                        abgelehnt.
+                      {% endifequal %}
+                    {% else %}
+                     Mit {{initiative.absolute_supporters|default:0}} Unterstützern wurde das Qurom von {{initiative.quorum}} nicht erreicht. Die Initiative wurde damit abgelehnt.
+                    {% endif %}
+                    </h3>
+                </div>
             </div>
-        </div>
-        <div class="row">
-            <div class="col-12">
-                {% if initiative.was_closed_at %}
-                <h3 class="history-title">
-			    <span class="date">{{initiative.was_closed_at}}</span>
-			    {% if initiative.went_to_discussion_at %}
-			      Nach Abstimmung mit {{ initiative.yays|default:0 }} Für- und {{ initiative.nays|default:0 }} Gegenstimmen
-			      {% ifequal initiative.state 'a' %}
-			        angenommen.
-			      {% else %}
-			        abgelehnt.
-			      {% endifequal %}
-			    {% else %}
-			     Mit {{initiative.absolute_supporters|default:0}} Unterstützern wurde das Qurom von {{initiative.quorum}} nicht erreicht. Die Initiative wurde damit abgelehnt.
-			    {% endif }
-			    {% endif %}
-			    </h3> {% endif %}
-			</div>
-		</div>
+        {% endif %}
     </div>
 </div>
 

--- a/voty/initproc/admin.py
+++ b/voty/initproc/admin.py
@@ -17,6 +17,13 @@ class SupporterAdmin(admin.ModelAdmin):
 	search_fields = ['initiative__title', 'user__username', 'user__first_name', 'user__last_name']
 
 
+class ModerationAdmin(admin.ModelAdmin):
+	list_display = ['created_at', 'initiative', 'user', 'vote', 'stale']
+	ordering = ['created_at']
+
+	search_fields = ['initiative__title', 'user__username', 'user__first_name', 'user__last_name']
+
+
 admin.site.register(Initiative, InitiativeAdmin)
 admin.site.register(Quorum)
 admin.site.register(Supporter, SupporterAdmin)
@@ -24,5 +31,5 @@ admin.site.register(Pro)
 admin.site.register(Contra)
 admin.site.register(Proposal)
 admin.site.register(Comment)
-admin.site.register(Moderation)
+admin.site.register(Moderation, ModerationAdmin)
 admin.site.register(Vote)

--- a/voty/initproc/admin.py
+++ b/voty/initproc/admin.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
+from reversion.admin import VersionAdmin
+
 from .models import Initiative, Quorum, Supporter, Pro, Contra, Proposal, Comment, Vote, Moderation
 
-
-class InitiativeAdmin(admin.ModelAdmin):
+class InitiativeAdmin(VersionAdmin):
     list_display = ['title', 'state', 'created_at', 'changed_at']
     ordering = ['title', 'created_at', 'changed_at']
     # actions = ['move_on', 'send_invite', 'decline']

--- a/voty/initproc/globals.py
+++ b/voty/initproc/globals.py
@@ -48,6 +48,11 @@ STAFF_ONLY_STATES = [STATES.INCOMING,
                      STATES.HIDDEN]
 
 
+COMPARING_FIELDS = [
+    'title', 'subtitle',  "summary", "problem", "forderung", "kosten",
+    "fin_vorschlag", "arbeitsweise", "init_argument",
+    "einordnung", "ebene", "bereich",
+]
 
 
 SPEED_PHASE_END = date(2017, 8, 21) # Everything published before this has speed phase

--- a/voty/initproc/guard.py
+++ b/voty/initproc/guard.py
@@ -193,6 +193,8 @@ class Guard:
             return False
         if not self.user.is_authenticated:
             return False
+        if self.user.is_superuser:
+            return True
         if not init.supporting.filter(initiator=True, user_id=self.request.user.id):
             return False
 

--- a/voty/initproc/guard.py
+++ b/voty/initproc/guard.py
@@ -193,7 +193,7 @@ class Guard:
             return False
         if not self.user.is_authenticated:
             return False
-        if not init.supporting.filter(Q(first=True) | Q(initiator=True), user_id=self.request.user.id):
+        if not init.supporting.filter(initiator=True, user_id=self.request.user.id):
             return False
 
         return True

--- a/voty/initproc/models.py
+++ b/voty/initproc/models.py
@@ -5,8 +5,10 @@ from django.contrib.auth.models import User
 from django.db.models import Q
 from django.utils.text import slugify
 from django.conf import settings
+from reversion.models import Version
 
 from pinax.notifications.models import send as notify
+import reversion
 
 from datetime import datetime, timedelta, date
 
@@ -14,6 +16,8 @@ from .globals import STATES, INITIATORS_COUNT, SPEED_PHASE_END
 from django.db import models
 import pytz
 
+
+@reversion.register()
 class Initiative(models.Model):
 
     # fallback 
@@ -70,6 +74,10 @@ class Initiative(models.Model):
     @cached_property
     def slug(self):
         return slugify(self.title)
+
+    @cached_property
+    def versions(self):
+        return Version.objects.get_for_object(self)
 
 
     @cached_property

--- a/voty/initproc/urls.py
+++ b/voty/initproc/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     url('^initiative/(?P<init_id>\d+)(?:-(?P<slug>.*))?/new_moderation$', views.moderate),
     url('^initiative/(?P<init_id>\d+)(?:-(?P<slug>.*))?/vote$', views.vote, name="vote"),
     url('^initiative/(?P<init_id>\d+)(?:-(?P<slug>.*))?/reset_vote$', views.reset_vote, name="reset_vote"),
+    url('^initiative/(?P<init_id>\d+)(?:-(?P<slug>.*))?/compare/(?P<version_id>\d+)$', views.compare),
     url('^initiative/(?P<init_id>\d+)(?:-(?P<slug>.*))?/invite/(?P<invite_type>.*)$', views.invite),
     url('^initiative/(?P<init_id>\d+)(?:-(?P<slug>.*))?/moderation/(?P<target_id>\d+)$', views.show_moderation),
     url('^initiative/(?P<init_id>\d+)(?:-(?P<slug>.*))?/(?P<target_type>.*)/(?P<target_id>\d+)$', views.show_resp),

--- a/voty/initproc/views.py
+++ b/voty/initproc/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.views.decorators.http import require_POST
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.utils.decorators import available_attrs
+from django.utils.safestring import mark_safe
 from django.contrib.auth import get_user_model
 from django.contrib import messages
 from django.apps import apps
@@ -13,11 +14,13 @@ from django import forms
 from datetime import datetime
 from django_ajax.decorators import ajax
 from pinax.notifications.models import send as notify
+from reversion_compare.helpers import html_diff
+from reversion.models import Version
 import reversion
 
 from functools import wraps
 
-from .globals import NOTIFICATIONS, STATES, INITIATORS_COUNT
+from .globals import NOTIFICATIONS, STATES, INITIATORS_COUNT, COMPARING_FIELDS
 from .guard import can_access_initiative
 from .models import (Initiative, Pro, Contra, Proposal, Comment, Vote, Moderation, Quorum, Supporter, Like)
 from .forms import (simple_form_verifier, InitiativeForm, NewArgumentForm, NewCommentForm,
@@ -116,7 +119,7 @@ def new(request):
                 if request.POST.get('commit_message', None):
                     reversion.set_comment(request.POST.get('commit_message'))
 
-                    
+
             Supporter(initiative=ini, user=request.user, initiator=True, ack=True, public=True).save()
             return redirect('/initiative/{}-{}'.format(ini.id, ini.slug))
         else:
@@ -530,6 +533,33 @@ def vote(request, init):
                                     context=dict(vote=my_vote, initiative=init),
                                     request=request)
         }}
+
+
+
+@non_ajax_redir('/')
+@ajax
+@can_access_initiative()
+def compare(request, initiative, version_id):
+    versions = Version.objects.get_for_object(initiative)
+    latest = versions.first()
+    selected = versions.filter(id=version_id).first()
+    compare = {key: mark_safe(html_diff(selected.field_dict.get(key, ''),
+                                        latest.field_dict.get(key, '')))
+            for key in COMPARING_FIELDS}
+
+    compare['went_public_at'] = initiative.went_public_at
+
+
+    return {
+        'inner-fragments': {
+            'header': "",
+            '.main': render_to_string("fragments/compare.html",
+                                      context=dict(initiative=initiative,
+                                                    selected=selected,
+                                                    latest=latest,
+                                                    compare=compare),
+                                      request=request)}
+    }
 
 
 

--- a/voty/initproc/views.py
+++ b/voty/initproc/views.py
@@ -247,6 +247,8 @@ def edit(request, initiative):
                 if request.POST.get('commit_message', None):
                     reversion.set_comment(request.POST.get('commit_message'))
 
+            initiative.supporting.filter(initiator=True).update(ack=False)
+
             messages.success(request, "Initiative gespeichert.")
             initiative.notify_followers(NOTIFICATIONS.INITIATIVE.EDITED, subject=request.user)
             return redirect('/initiative/{}'.format(initiative.id))

--- a/voty/settings.py
+++ b/voty/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'bootstrapform',
     'fullurl',
     'django_ajax',
+    'reversion',
 
     # must be before admin ...
     'dal',


### PR DESCRIPTION
Von nun an halten wir beim Überarbeiten eine Kopie der vorherigen Version der Initiative vor. Wenn das dieses kleine Symbol auf der Initiative auftaucht,
![screenshot sat jul 08 2017 23 15 05 gmt 0200 cest 785x415](https://user-images.githubusercontent.com/40496/27989285-064366d6-6436-11e7-9041-27c409933d45.png)

kannst du per klick darauf die Historie sehen, die dir einen vergleich mit der aktuellen Fassung erlaubt:
![screenshot sat jul 08 2017 23 06 11 gmt 0200 cest 928x1246](https://user-images.githubusercontent.com/40496/27989290-2150a204-6436-11e7-8eec-8187d1297eb0.png)

 