### PR TITLE
show missing supporter count in index page if state is "seeking support"

### DIFF
--- a/templates/fragments/initiative/card.html
+++ b/templates/fragments/initiative/card.html
@@ -1,4 +1,5 @@
 {% load guard %}
+{% load mathfilters %}
 {% load fullurl %}
 <div id="init-card-{{initiative.id}}" class="card">
 	<div class="card-header">
@@ -29,7 +30,12 @@
 
 					{% ifequal initiative.state 's' %}
 					<span class="badge badge-support">
-						Sucht Unterstützung
+						Sucht Unterstützung -
+						{% if initiative.absolute_supporters < initiative.quorum %}
+						  {{initiative.quorum|sub:initiative.absolute_supporters}} fehlende {% if initiative.quorum|sub:initiative.absolute_supporters == 1 %}Unterstützer/in{% else %}Unterstützer/innen{% endif %}
+					    {% else %}
+						  Quorum erreicht
+					    {% endif %}
 					</span>
 					{% endifequal %}
 


### PR DESCRIPTION
i decided to add the number of supporters to the badge, because the progress bar doesn't fit into the card layout, and i didnt know where else to put it