### PR TITLE
made button to jump to vote responsive to vote status

### DIFF
--- a/templates/fragments/jump_to_vote.html
+++ b/templates/fragments/jump_to_vote.html
@@ -1,0 +1,3 @@
+<a href="#vote" class="btn bg-vote" id="jump-to-vote">
+    {% if vote %}Deine Stimme{% else %}Jetzt abstimmen{% endif %}
+</a>

--- a/templates/initproc/item.html
+++ b/templates/initproc/item.html
@@ -328,9 +328,7 @@
             <div class="col-12">
                 <h6 class="text-muted classification">Noch {{initiative.end_of_this_phase | timeuntil}}</h6>
                 <p>Über diese Initiative wird gerade abgestimmt.</p>
-                <a href="#vote" class="btn bg-vote">
-                    Jetzt abstimmen
-                </a>
+                {% include "fragments/jump_to_vote.html" %}
             </div>
         </div>
     </div>

--- a/voty/initproc/views.py
+++ b/voty/initproc/views.py
@@ -61,6 +61,16 @@ def non_ajax_redir(*redir_args, **redir_kwargs):
         return inner
     return decorator
 
+def get_voting_fragments(vote,initiative,request):
+    context = dict(vote=vote, initiative=initiative, user_count=get_user_model().objects.count())
+    return {'fragments': {
+        '#voting': render_to_string("fragments/voting.html",
+                                    context=context,
+                                    request=request),
+        '#jump-to-vote': render_to_string("fragments/jump_to_vote.html",
+                                    context=context)
+        }}
+
 #
 # ____    ____  __   ___________    __    ____   _______.
 # \   \  /   / |  | |   ____\   \  /  \  /   /  /       |
@@ -607,12 +617,7 @@ def vote(request, init):
         my_vote.reason = reason
     my_vote.save()
 
-    return {'fragments': {
-        '#voting': render_to_string("fragments/voting.html",
-                                    context=dict(vote=my_vote, initiative=init),
-                                    request=request)
-        }}
-
+    return get_voting_fragments (my_vote,init,request)
 
 
 @non_ajax_redir('/')
@@ -649,8 +654,4 @@ def compare(request, initiative, version_id):
 @can_access_initiative(STATES.VOTING) # must be in voting
 def reset_vote(request, init):
     Vote.objects.filter(initiative=init, user_id=request.user).delete()
-    return {'fragments': {
-        '#voting': render_to_string("fragments/voting.html",
-                                    context=dict(vote=None, initiative=init),
-                                    request=request)
-        }}
+    return get_voting_fragments (None,init,request)


### PR DESCRIPTION
Der Button, der zur Abstimmung springt, heißt bisher immer "Jetzt abstimmen", auch wenn mensch schon abgestimmt hat. Mit dieser Änderung passt er sich in beiden Richtungen unmittelbar an, beim Abstimmen und beim Stimme zurücknehmen. Wenn schon abgestimmt wurde, ist das Label "Deine Stimme" -- da ließe sich vielleicht noch was Besseres finden.

Der Kontext-Eintrag `user_count=get_user_model().objects.count()` ist für Kompatibilität mit https://github.com/DemokratieInBewegung/abstimmungstool/pull/24.

Ich hab das Fragment-Rendering aus `vote ()` und `reset_vote ()` in eine Funktion `get_voting_fragments ()` ausgelagert, um die Dopplung zu vermeiden -- ich kenn mich aber nicht mit der Sicherheitsarchitektur hier aus und bin nicht sicher, ob davor noch sowas wie `@can_access_initiative` stehn müsste. (Am besten sollte das ja sowieso eine lokale/private Funktion sein, aber das gibt es anscheinend in Python nicht so richtig?)