### PR TITLE
fixed discrepancy between DiB and Django character counts

### DIFF
--- a/static/js/dib/utils.js
+++ b/static/js/dib/utils.js
@@ -107,7 +107,7 @@ function setup_char_counter(prefix){
   $((prefix || '') + "[maxlength]").keyup(function(evt){
     var t = $(evt.currentTarget);
     $('[for=' + t.attr('id') + ']'
-      ).attr("data-text-after", "(noch " + (parseInt(t.attr('maxlength')) - t.val().length) + " Zeichen)");
+      ).attr("data-text-after", "(noch " + (parseInt(t.attr('maxlength')) - t.val().replace(/\n/g,"\n\n").length) + " Zeichen)");
   }).keyup();
 
 }


### PR DESCRIPTION
This fixes https://wekan.bewegung.jetzt/b/uQJxjrioxz2EG9nLi/initiativ-tool/A7itbqr3o6uQcHsC3. It would seem preferable to make Django count newlines once; since I don't know how to do that, I made DiB count them twice.