### PR TITLE
Add JSON serializer to JSON response

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,11 +16,13 @@ git+https://github.com/DemokratieInBewegung/django-mailer.git
 django-mathfilters==0.4.0
 django-model-utils==3.0.0
 django-notifications-hq==1.2
+django-rest-framework==0.1.0
 django-reversion==2.0.9
 django-reversion-compare==0.7.5
 django-tag-parser==2.1
 django-user-accounts==2.0.1
 djangoajax==2.3.7
+djangorestframework==3.7.1
 dominate==2.1.17
 easy-thumbnails==2.3
 gunicorn==19.7.1
@@ -34,7 +36,7 @@ olefile==0.44
 packaging==16.8
 Pillow==4.0.0
 pinax-notifications==4.0.0
-psycopg2==2.7.1
+psycopg2==2.7.3.2
 pyparsing==2.2.0
 python3-openid==3.1.0
 pytz==2017.2

--- a/voty/initproc/serializers.py
+++ b/voty/initproc/serializers.py
@@ -4,7 +4,7 @@ from .models import Initiative
 class SimpleInitiativeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Initiative
-        fields = ["title", "subtitle", "state", "created_at", 
+        fields = ["id", "title", "subtitle", "state", "created_at",
                   "changed_at","summary", "problem", "forderung",
                   "kosten", "fin_vorschlag", "arbeitsweise", "init_argument" ,
                   "einordnung", "ebene", "bereich", "went_public_at",

--- a/voty/initproc/serializers.py
+++ b/voty/initproc/serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+from .models import Initiative
+
+class SimpleInitiativeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Initiative
+        fields = ["title", "subtitle", "state", "created_at", 
+                  "changed_at","summary", "problem", "forderung",
+                  "kosten", "fin_vorschlag", "arbeitsweise", "init_argument" ,
+                  "einordnung", "ebene", "bereich", "went_public_at",
+                  "went_to_discussion_at", "went_to_voting_at", "was_closed_at",
+                  # and calculated fields also matter:
+                  "slug", "end_of_this_phase"]
+
+

--- a/voty/initproc/views.py
+++ b/voty/initproc/views.py
@@ -17,6 +17,7 @@ from django import forms
 
 from datetime import datetime, timedelta
 
+from rest_framework.renderers import JSONRenderer
 from django_ajax.shortcuts import render_to_json
 from django_ajax.decorators import ajax
 from pinax.notifications.models import send as notify
@@ -25,13 +26,15 @@ from reversion.models import Version
 import reversion
 
 from functools import wraps
+import json
 
 from .globals import NOTIFICATIONS, STATES, INITIATORS_COUNT, COMPARING_FIELDS
 from .guard import can_access_initiative
 from .models import (Initiative, Pro, Contra, Proposal, Comment, Vote, Moderation, Quorum, Supporter, Like)
 from .forms import (simple_form_verifier, InitiativeForm, NewArgumentForm, NewCommentForm,
                     NewProposalForm, NewModerationForm, InviteUsersForm)
-# Create your views here.
+from .serializers import SimpleInitiativeSerializer
+
 
 DEFAULT_FILTERS = [
     STATES.PREPARE,
@@ -133,7 +136,13 @@ def index(request):
                 '#init-list': render_to_string("fragments/initiative/list.html",
                                                context=dict(initiatives=inits),
                                                request=request)
-             }
+             },
+             # FIXME: ugly work-a-round as long as we use django-ajax
+             #        for rendering - we have to pass it as a dict
+             #        or it chokes on rendering :(
+             'initiatives': json.loads(JSONRenderer().render(
+                                SimpleInitiativeSerializer(inits, many=True).data,
+                            ))
         }
 )
 


### PR DESCRIPTION
When asking for a JSON response, don't only return html-fragments, but also
return with proper JSON representation of the intiatives.

This implements that behaviour for /index (only) using the django-restframework
serializer infrastructure. This therefore also includes the new dependency
django-restframework.