### PR TITLE
Fixed duration of voting phase

### DIFF
--- a/voty/initproc/models.py
+++ b/voty/initproc/models.py
@@ -176,7 +176,7 @@ class Initiative(models.Model):
                     return self.went_to_discussion_at + (5 * week)
 
                 elif self.state == 'v':
-                    return self.went_to_voting_at + (2 * week)
+                    return self.went_to_voting_at + (3 * week)
 
         return None
 


### PR DESCRIPTION
The duration of the voting phase had been incorrectly set to two weeks, and apparently no one noticed for 8 months!!